### PR TITLE
consistent-type-imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -104,6 +104,7 @@
         "import/no-duplicates": "error",
         "import/no-unresolved": "error",
         "@typescript-eslint/no-unused-vars": "warn",
+        "@typescript-eslint/consistent-type-imports": ["error", { "prefer": "type-imports" }],
         // Style
         "max-len": [
             "error",

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -15,7 +15,8 @@
             "~src/*": ["src/*"],
             "~resources/*": ["resources/*"]
         },
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "importsNotUsedAsValues": "error"
     },
     "include": ["./src/**/*", "./test/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
             "~src/*": ["src/*"],
             "~resources/*": ["resources/*"]
         },
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "importsNotUsedAsValues": "error"
     },
     "include": ["./src/**/*"]
 }


### PR DESCRIPTION
* eslint rule: @typescript-eslint/consistent-type-imports
* TypeScript option: importsNotUsedAsValues